### PR TITLE
Add Due and DueCategory models | Add GQL API for Dues query

### DIFF
--- a/swd/.gitignore
+++ b/swd/.gitignore
@@ -14,3 +14,4 @@ dev_info.py
 .vscode/
 studentimgs
 studentimg
+*.swp

--- a/swd/frontend/yarn.lock
+++ b/swd/frontend/yarn.lock
@@ -1420,6 +1420,11 @@ core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
 
+core-js@^2.4.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.1.tgz#87416ae817de957a3f249b3b5ca475d4aaed6042"
+  integrity sha512-L72mmmEayPJBejKIWe2pYtGis5r0tQ5NaJekdhyXgeMQTpJoBsH0NL4ElY2LfSoV15xeQWKQ+XTTOZdyero5Xg==
+
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -2161,6 +2166,11 @@ fb-watchman@^1.8.0, fb-watchman@^1.9.0:
   dependencies:
     bser "1.0.2"
 
+fbjs-css-vars@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
+  integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
+
 fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.6:
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
@@ -2172,6 +2182,20 @@ fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.6:
     promise "^7.1.1"
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
+
+fbjs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-1.0.0.tgz#52c215e0883a3c86af2a7a776ed51525ae8e0a5a"
+  integrity sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==
+  dependencies:
+    core-js "^2.4.1"
+    fbjs-css-vars "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
 
 figures@^1.3.5:
   version "1.7.0"
@@ -2508,9 +2532,16 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@^2.2.0, hoist-non-react-statics@^2.3.0, hoist-non-react-statics@^2.3.1:
+hoist-non-react-statics@^2.3.0, hoist-non-react-statics@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
+
+hoist-non-react-statics@^3.0.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz#c09c0555c84b38a7ede6912b61efddafd6e75e1e"
+  integrity sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==
+  dependencies:
+    react-is "^16.3.2"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -3390,6 +3421,11 @@ lodash.isarray@^3.0.0:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lodash.isarray/-/lodash.isarray-3.0.4.tgz#79e4eb88c36a8122af86f844aa9bcd851b5fbb55"
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
+
 lodash.keys@^3.0.0:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/lodash.keys/-/lodash.keys-3.1.2.tgz#4dbc0472b156be50a0b286855d1bd0b0c656098a"
@@ -3405,10 +3441,6 @@ lodash.memoize@^4.1.2:
 lodash.merge@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
-
-lodash.pick@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
 
 lodash.pickby@^4.6.0:
   version "4.6.0"
@@ -4410,16 +4442,17 @@ react-addons-css-transition-group@^15.6.2:
   dependencies:
     react-transition-group "^1.2.0"
 
-react-apollo@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.0.4.tgz#01dd32a8e388672f5d7385b21cdd0b94009ee9ee"
+react-apollo@^2.1.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.3.3.tgz#a4609f3112d4351a1e363090d8cd363b04e2cc91"
+  integrity sha512-y4CwwmJjp0De/An7vrvEWOJ27lxmS/SXT8z22I8aOEBC2wzdcavDPjKzeLYJKs+hv1MGS3h84PSwFtlU4Em/bA==
   dependencies:
-    apollo-link "^1.0.0"
-    hoist-non-react-statics "^2.2.0"
-    invariant "^2.2.1"
+    fbjs "^1.0.0"
+    hoist-non-react-statics "^3.0.0"
+    invariant "^2.2.2"
     lodash.flowright "^3.5.0"
-    lodash.pick "^4.4.0"
-    prop-types "^15.5.8"
+    lodash.isequal "^4.5.0"
+    prop-types "^15.6.0"
 
 react-content-loader@^3.1.1:
   version "3.1.1"
@@ -4457,6 +4490,11 @@ react-event-listener@^0.5.1:
     fbjs "^0.8.16"
     prop-types "^15.6.0"
     warning "^3.0.0"
+
+react-is@^16.3.2:
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
+  integrity sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==
 
 react-responsive@^3.0.0:
   version "3.0.0"
@@ -5262,6 +5300,11 @@ type-is@~1.6.15:
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
+ua-parser-js@^0.7.18:
+  version "0.7.19"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
+  integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
 
 ua-parser-js@^0.7.9:
   version "0.7.17"

--- a/swd/main/admin.py
+++ b/swd/main/admin.py
@@ -14,7 +14,7 @@ from .resources import *
 class HostelPSAdmin(admin.ModelAdmin):
     search_fields = ['student__name', 'student__bitsId']
 
-models = [Warden, Staff, DayScholar, CSA, DayPass, LateComer, InOut, Disco, MessOptionOpen, Transaction, MessBill, TeeAdd, ItemAdd, HostelSuperintendent, Notice, FileAdd, Document, AntiRagging]
+models = [Warden, Staff, DayScholar, CSA, DayPass, LateComer, InOut, Disco, MessOptionOpen, Transaction, MessBill, TeeAdd, ItemAdd, HostelSuperintendent, Notice, FileAdd, Document, AntiRagging, DueCategory, Due]
 
 
 @admin.register(Bonafide)

--- a/swd/main/models.py
+++ b/swd/main/models.py
@@ -343,14 +343,23 @@ class ItemBuy(models.Model):
     def __str__(self):
         return self.student.bitsId + ' ' + self.item.title
 
-class Dues(models.Model):
-    student = models.ForeignKey('Student', on_delete = models.CASCADE)
-    month = models.DateField(blank=True, null=True)
-    amount = models.FloatField()
-    desc = models.CharField(max_length=100)
+class DueCategory(models.Model):
+    name = models.CharField(max_length=100)
+    description = models.CharField(max_length=500)
 
     def __str__(self):
-        return self.student.bitsId + ' ' + self.month
+        return "Due category with name {} and description '{}'".format(self.name, self.description)
+
+class Due(models.Model):
+    student = models.ForeignKey(Student, on_delete=models.CASCADE)
+    amount = models.FloatField()
+    due_category = models.ForeignKey(DueCategory, on_delete=models.CASCADE)
+    description = models.CharField(max_length=500)
+    date_added = models.DateField()
+
+    def __str__(self):
+        return self.student.bitsId + "'s due entry with amount " + str(self.amount)
+
 
 class Notice(models.Model):
     

--- a/swd/main/schema/queries.py
+++ b/swd/main/schema/queries.py
@@ -136,6 +136,13 @@ class Query(object):
         username = graphene.String()
     )
 
+    all_dues = graphene.List(DueType)
+    dues = graphene.List(
+        DueType,
+        id=graphene.Int(),
+        username=graphene.String()
+    )
+
     def resolve_current_user(self, args, **kwargs):
         context = args.context
         if not context.user.is_authenticated:
@@ -484,3 +491,20 @@ class Query(object):
             return MessBill.objects.filter(student=student)
 
         return None
+
+    def resolve_all_dues(self, args, **kwargs):
+        return Due.objects.all()
+
+    def resolve_dues(self, args, **kwargs):
+        id_ = kwargs.get('id')
+        username = kwargs.get('username')
+
+        if id_ is not None:
+            return [Due.objects.get(id=id_)]
+
+        if username is not None:
+            user = User.objects.get(username=username)
+            student = Student.objects.get(user=user)
+            return Due.objects.filter(student=student)
+
+        return []

--- a/swd/main/schema/types.py
+++ b/swd/main/schema/types.py
@@ -99,3 +99,11 @@ class TransactionType(DjangoObjectType):
 class MessBillType(DjangoObjectType):   
     class Meta:
         model = MessBill
+
+class DueCategoryType(DjangoObjectType):
+    class Meta:
+        model = DueCategory
+
+class DueType(DjangoObjectType):
+    class Meta:
+        model = Due


### PR DESCRIPTION
Also added `*.swp` to `.gitignore` to exclude vim swap files

Example query for list of dues for a student with given username:
```
{
    dues (username: "f20130487") {
        amount
    }
}
```

This returns (on dummy local data)
```
{
  "data": {
    "dues": [
      {
        "id": "1",
        "amount": 160000,
        "student": {
          "bitsId": "2013A1PS0487G"
        }
      }
    ]
  }
}
```