### PR TITLE
[WIP] Update recent admin views with the jet admin template

### DIFF
--- a/swd/main/urls.py
+++ b/swd/main/urls.py
@@ -36,7 +36,6 @@ urlpatterns = [
     url(r'^search/', views.search, name="search"),
     url(r'^student/(?P<id>\d+)/$',views.studentDetails, name="studentDetails"),
     url(r'^messbill/', views.messbill, name='messbill'),
-    url(r'^import_mess_bill/', views.import_mess_bill, name='import_mess_bill'),
     url(r'^notice/',views.notice, name='notice'),
     url(r'^antiragging/',views.antiragging, name='antiragging'),
     url(r'^swd/',views.swd, name='swd'),
@@ -45,11 +44,12 @@ urlpatterns = [
     url(r'^latecomer/', views.latecomer, name="latecomer"),
     url(r'^contact/',views.contact, name='contact'),
 
-    url(r'^mess-forgot/',views.mess_import, name='forgot'),
-    url(r'^mess_exp/',views.mess_exp, name='mess_exp'),
+    url(r'^admin/import_mess_bill/', views.import_mess_bill, name='import_mess_bill'),
+    url(r'^admin/mess-forgot/',views.mess_import, name='forgot'),
+    url(r'^admin/mess_exp/',views.mess_exp, name='mess_exp'),
     #url(r'^mess_filter/',views.mess_filter, name='mess_filter'),
-    url(r'^dues_dashboard/', views.dues_dashboard, name='dues_dashboard'),
-    url(r'^import_dues_from_sheet/', views.import_dues_from_sheet, name='import_dues_from_sheet'),
-    url(r'^publish_dues/', views.publish_dues, name='publish_dues'),
+    url(r'^admin/dues_dashboard/', views.dues_dashboard, name='dues_dashboard'),
+    url(r'^admin/import_dues_from_sheet/', views.import_dues_from_sheet, name='import_dues_from_sheet'),
+    url(r'^admin/publish_dues/', views.publish_dues, name='publish_dues'),
 
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/swd/main/urls.py
+++ b/swd/main/urls.py
@@ -45,7 +45,7 @@ urlpatterns = [
     url(r'^contact/',views.contact, name='contact'),
 
     url(r'^admin/import_mess_bill/', views.import_mess_bill, name='import_mess_bill'),
-    url(r'^admin/mess-forgot/',views.mess_import, name='forgot'),
+    url(r'^admin/mess_option_upload/',views.mess_import, name='forgot'),
     url(r'^admin/mess_exp/',views.mess_exp, name='mess_exp'),
     #url(r'^mess_filter/',views.mess_filter, name='mess_filter'),
     url(r'^admin/dues_dashboard/', views.dues_dashboard, name='dues_dashboard'),

--- a/swd/main/views.py
+++ b/swd/main/views.py
@@ -993,7 +993,7 @@ def antiragging(request):
 
 @user_passes_test(lambda u: u.is_superuser)
 def mess_import(request):  
-
+    updateTxt=''
     no_of_mess_option_added = 0
     if request.POST:
         if request.FILES:
@@ -1019,8 +1019,9 @@ def mess_import(request):
                     my = datetime(date.today().year, month, 1)
                     messop = MessOption.objects.create(student = s, monthYear = my, mess = str(i[2].value))
                     no_of_mess_option_added += 1
-
-    context = {'added': no_of_mess_option_added}
+            updateTxt = "{} entries added to the database from this upload"
+            messages.success(request, updateTxt.format(no_of_mess_option_added))
+    context = {'added': updateTxt}
     return render(request, "mess_defaulters_upload.html", context)
 
 @user_passes_test(lambda u: u.is_superuser)
@@ -1075,6 +1076,9 @@ def mess_exp(request):
             row_num += 1
             for col_num in range(len(s)):
                 ws.write(row_num, col_num, s[col_num], font_style)
+
+        updateTxt = "{} entries added to the database from this upload"
+        messages.success(request, updateTxt.format(row_num))
 
         wb.save(response)
         return response 

--- a/swd/templates/dues_dashboard.html
+++ b/swd/templates/dues_dashboard.html
@@ -1,4 +1,8 @@
-{% extends 'base.html' %}
+{% extends "admin/base_site.html" %}
+
+{% block title %}
+Dues Import | Admin
+{% endblock title %}
 
 {% block content %}
 	<div class="container">

--- a/swd/templates/mess_defaulters_upload.html
+++ b/swd/templates/mess_defaulters_upload.html
@@ -1,16 +1,19 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+
+<p>Upload the list of Mess Defaulters</p>
+
 <form method="POST", enctype="multipart/form-data">
 
 	{%csrf_token%}
-	<label>Upload a xls</label>
 	<input type="file" name="file">
-	<p>Upload xls</p>
 	<button type="submit">Upload</button>
 
 </form>
 
 {%if added %}
-	<p>The number of entries added = {{added}}</p>
-	{%else%}
-		<p>No entries added till now</p>
+	<p>{{added}}</p>
 {%endif%}
 
+{% endblock content %}

--- a/swd/templates/mess_export.html
+++ b/swd/templates/mess_export.html
@@ -1,3 +1,6 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
 <p>Select year and month of mess defaulters</p>
 <form method="POST">
 	
@@ -21,3 +24,5 @@
 
 
 </form>
+
+{% endblock content %}


### PR DESCRIPTION
Fixes #193 
**DO NOT MERGE**
- Prepend admin-only-access urls with `/admin/` 
- Use `messages` Django backed to display changes from uploads (in recently added views)
- Change the base of templates to jet admin base.

**Minor Fix**
- More readable url address for importing mess option

**Issues:**
- The dropdown items can not be selected in `/admin/mess_exp/` (may be my browser specific problem)