### PR TITLE
Allows PhD, Thesis and PS Student Search

### DIFF
--- a/swd/main/views.py
+++ b/swd/main/views.py
@@ -1442,7 +1442,7 @@ def search(request):
            'branches' : BRANCH,
            'permission': perm,
            'option' :option,
-           'student' :student ,
+           'student' :student,
            'leaves': leaves,
            'option': option,
            'mess': mess,
@@ -1451,7 +1451,6 @@ def search(request):
            'balance': balance
         }
 
-      
     postContext = {}
     if request.GET:
         name = request.GET.get('name')
@@ -1461,10 +1460,10 @@ def search(request):
         room = request.GET.get('room')
 
         students = Student.objects.filter(
-            Q(name__icontains=name) & 
-            Q(bitsId__icontains=bitsId) & 
-            Q(bitsId__contains=branch) &    
-            (Q(hostelps__hostel__contains=hostel) & 
+            Q(name__icontains=name) &
+            Q(bitsId__icontains=bitsId) &
+            Q(bitsId__contains=branch) &
+            (Q(hostelps__hostel__contains=hostel) &
             Q(hostelps__room__contains=room) |
             Q(hostelps__psStation__contains=''))
         )
@@ -1507,12 +1506,13 @@ def search_no_login(request):
         room = request.GET.get('room')
 
         students = Student.objects.filter(
-            Q(name__icontains=name) & 
-            Q(bitsId__icontains=bitsId) & 
-            Q(bitsId__contains=branch) &    
-            (Q(hostelps__hostel__contains=hostel) & 
+            Q(name__icontains=name) &
+            Q(bitsId__icontains=bitsId) &
+            Q(bitsId__contains=branch) &
+            (Q(hostelps__hostel__contains=hostel) &
             Q(hostelps__room__contains=room) |
-            Q(hostelps__psStation__contains=''))
+            Q(hostelps__psStation__contains='') |
+            Q(bitsId__icontains='PH'))
         )
         
         searchstr = {}

--- a/swd/main/views.py
+++ b/swd/main/views.py
@@ -1465,7 +1465,8 @@ def search(request):
             Q(bitsId__contains=branch) &
             (Q(hostelps__hostel__contains=hostel) &
             Q(hostelps__room__contains=room) |
-            Q(hostelps__psStation__contains=''))
+            Q(hostelps__psStation__contains='') |
+            Q(bitsId__icontains='PH'))
         )
 
         searchstr = {}

--- a/swd/main/views.py
+++ b/swd/main/views.py
@@ -1460,7 +1460,14 @@ def search(request):
         hostel = request.GET.get('hostel')
         room = request.GET.get('room')
 
-        students = Student.objects.filter(Q(name__icontains=name) & Q(bitsId__icontains=bitsId) & Q(bitsId__contains=branch) & Q(hostelps__hostel__contains=hostel) & Q(hostelps__room__contains=room))
+        students = Student.objects.filter(
+            Q(name__icontains=name) & 
+            Q(bitsId__icontains=bitsId) & 
+            Q(bitsId__contains=branch) &    
+            (Q(hostelps__hostel__contains=hostel) & 
+            Q(hostelps__room__contains=room) |
+            Q(hostelps__psStation__contains=''))
+        )
 
         searchstr = {}
 
@@ -1499,8 +1506,15 @@ def search_no_login(request):
         hostel = request.GET.get('hostel')
         room = request.GET.get('room')
 
-        students = Student.objects.filter(Q(name__icontains=name) & Q(bitsId__contains=bitsId) & Q(bitsId__contains=branch) & Q(hostelps__hostel__contains=hostel) & Q(hostelps__room__contains=room))
-
+        students = Student.objects.filter(
+            Q(name__icontains=name) & 
+            Q(bitsId__icontains=bitsId) & 
+            Q(bitsId__contains=branch) &    
+            (Q(hostelps__hostel__contains=hostel) & 
+            Q(hostelps__room__contains=room) |
+            Q(hostelps__psStation__contains=''))
+        )
+        
         searchstr = {}
 
         if name is not "":

--- a/swd/templates/search.html
+++ b/swd/templates/search.html
@@ -2,7 +2,6 @@
 
 <div class="container">
     <div class="section">
-
         <!--   Icon Section   -->
         <div class="row">
             <div class="col s12 m12">
@@ -32,10 +31,6 @@
                                 </select>
                                 <label>Branch</label>
                             </div>
-                            <!-- <div class="input-field col s3">
-                            <input name="branch" id="branch" type="text" class="validate">
-                            <label for="branch">Branch</label>
-                        </div> -->
                         </div>
 
                         <div class="row">
@@ -80,8 +75,7 @@
                                         <th>Sr. No.</th>
                                         <th>Student ID</th>
                                         <th>Name</th>
-                                        <th>Hostel</th>
-                                        <th>Room</th>
+                                        <th colspan=2>Hostel Room / PS</th>
                                     </tr>
                                 </thead>
 
@@ -95,8 +89,12 @@
                                         {% else %}
                                         <td>{{ i.name }}</td>
                                         {% endif %}
+                                        {% if i.hostelps.room %}
                                         <td>{{ i.hostelps.hostel }}</td>
                                         <td>{{ i.hostelps.room }}</td>
+                                        {% elif i.hostelps.psStation %}
+                                        <td colspan=2>{{ i.hostelps.psStation }}</td>
+                                        {% endif %}
                                     </tr>
                                     {% endfor %}
                                 </tbody>

--- a/swd/templates/search.html
+++ b/swd/templates/search.html
@@ -10,7 +10,6 @@
                     <br>
                     <h5 class="center">Search Students</h5>
                     <form method="GET">
-                        {% csrf_token %}
                         <div class="row">
                             <div class="input-field col s10 offset-s1">
                                 <input name="name" id="name" type="text" class="validate">
@@ -75,7 +74,7 @@
                                         <th>Sr. No.</th>
                                         <th>Student ID</th>
                                         <th>Name</th>
-                                        <th colspan=2>Hostel Room / PS</th>
+                                        <th colspan=2>Hostel / Room or PS</th>
                                     </tr>
                                 </thead>
 
@@ -85,15 +84,25 @@
                                         <td>{{forloop.counter}}</td>
                                         <td>{{ i.bitsId }}</td>
                                         {% if permission == 1 %}
-                                        <td><a href="/student/{{ i.id }}/">{{ i.name }}</a></td>
+                                            <td><a href="/student/{{ i.id }}/">{{ i.name }}</a></td>
                                         {% else %}
-                                        <td>{{ i.name }}</td>
+                                            <td>{{ i.name }}</td>
                                         {% endif %}
-                                        {% if i.hostelps.room %}
-                                        <td>{{ i.hostelps.hostel }}</td>
-                                        <td>{{ i.hostelps.room }}</td>
+                                        {% if i.hostelps.hostel %}
+                                            {% if i.hostelps.room %}
+                                                {% comment %} REGULAR STUDENT {% endcomment %}
+                                                <td>{{ i.hostelps.hostel }}</td>
+                                                <td>{{ i.hostelps.room }}</td>
+                                            {% else %}
+                                                {% comment %} DAY SCHOLARS {% endcomment %}
+                                                <td colspan=2>{{ i.hostelps.hostel }}</td>
+                                            {% endif %}
                                         {% elif i.hostelps.psStation %}
-                                        <td colspan=2>{{ i.hostelps.psStation }}</td>
+                                            {% comment %} PS-2 STUDENTS {% endcomment %}
+                                            <td colspan=2>{{ i.hostelps.psStation }}</td>
+                                        {% else %}
+                                            {% comment %} THESIS STUDENTS {% endcomment %}
+                                            <td colspan=2>{{ i.hostelps.status }}</td>
                                         {% endif %}
                                     </tr>
                                     {% endfor %}


### PR DESCRIPTION
Addresses issue #236 

- Allows PhD, Thesis and PS2 students search from the search box.
- Removes CSRF Token in search. It is not required in "GET" requests.

Screenshot:
![image](https://user-images.githubusercontent.com/14289068/74829964-273ffb80-5338-11ea-82d6-329152938a8c.png)
