### PR TITLE
Added tabs to student dashboard

### DIFF
--- a/swd/templates/base.html
+++ b/swd/templates/base.html
@@ -44,6 +44,10 @@
                 <a href="/#" class="brand-logo"><img id="swd" src="{% static 'img/swd.png' %}"></a>
             <a href="#" data-activates="mobile-demo" class="button-collapse"><i class="material-icons">menu</i></a>
             <ul id="nav-mobile" class="right hide-on-med-and-down">
+                <li><a href="/swd">Services</a></li>
+                <li><a href="/csa">CSA</a></li>
+                <li><a href="/sac">SAC</a></li>
+                <li><a href="/contact">Contact Us</a></li>                
                 <li class=""><a href="/profile" class="valign-wrapper"><img class="circle profileImg" src="/media/{{ student.profile_picture }}">&nbsp;{{ student.name|title }}</a></li>
                 <li><a href="/logout">Logout</a></li>
             </ul>


### PR DESCRIPTION
Added Services, CSA, SAC and Contact Us tabs to student dashboard. After navigating to one of these pages, the student can return to the student dashboard after clicking on ['Home'](url) on any of these pages. This solves issue number #243 
File changed:
base.html

<img width="760" alt="hello" src="https://user-images.githubusercontent.com/59691764/88533096-4f3c3500-d023-11ea-8766-b01e67e304a6.png">