### PR TITLE
Fixed #356 - vacation tab now appears selected

### DIFF
--- a/swd/templates/base.html
+++ b/swd/templates/base.html
@@ -102,7 +102,7 @@
                 <li class="tab"><a href="/documents" class="{% active_page request 'documents' %}" target="_self">Documents</a></li>
                 <li class="tab"><a href="/search" class="{% active_page request 'search' %}" target="_self">Search</a></li>
                 <li class="tab"><a href="/submit_mcn" class="{% active_page request 'submit_mcn' %}" target="_self">MCN</a></li>
-                <li class="tab"><a href="/vacation" class="{% active_page request 'vacation' %}" target="_self">Vacation</a></li>
+                <li class="tab"><a href="/vacation" class="{% active_page request 'vacation_no_mess' %}" target="_self">Vacation</a></li>
             </ul>
         </div>
         {% endif %}


### PR DESCRIPTION
**Modified `base.html`**
Vacation tab now appears selected when clicked on (problem was due to incorrect request param)