### PR TITLE
Bonafide Update

### DIFF
--- a/swd/main/models.py
+++ b/swd/main/models.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import User
 import os
 import hashlib
 import re
+import random
 from django.utils import timezone
 from datetime import datetime
 from datetime import date
@@ -261,12 +262,10 @@ class Bonafide(models.Model):
     rejectedReason = models.TextField(default='', blank=True)
 
     def createText(self):
-
-        with open(settings.CONSTANTS_LOCATION, 'r') as fp:
-            data = json.load(fp)
-
-        gender = "Mr. " if self.student.gender.lower() == 'm' else "Ms. "
-        pronoun = "He " if gender == "Mr. " else "She "
+        gender = "M" if self.student.gender.lower() == 'm' else "F"
+        honorific = "Mr." if gender == "M" else "Ms."
+        pronoun = "He" if gender == "M" else "She"
+        possessive = "His" if gender == "M" else "Her"
         firstDeg = self.student.bitsId[4:6]
         secondDeg = self.student.bitsId[6:8]
         res = HostelPS.objects.get(student=self.student)
@@ -289,10 +288,37 @@ class Bonafide(models.Model):
         else:
             year = today.year
         reason = self.otherReason if self.reason.lower() == 'other' else self.reason
+
+        # Address will be shown in case reason is "Passport"
+        address = self.student.address
+        formatted_address = re.sub(r'\s*,\s*', ", ", address).strip(", ")
+        address_html_for_passport = f'''
+        <p>
+            {possessive} permanent address as per our records is: {formatted_address}
+        </p>
+        '''.strip()
+
         if(res.status == "Student"):
-            return f'''&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This is to certify that <i style="font-family: Monotype Corsiva">{gender + self.student.name.upper()}</i>, ID No. <i style="font-family: Monotype Corsiva">{self.student.bitsId}</i> is a bonafide student of {yearName} year class. {pronoun} was admitted to the Institute on {str(date_admit)}, for pursuing the <i style="font-family: Monotype Corsiva">{branch}</i> {"under dual degree " if dual_degree_student else ""}programme of studies. {pronoun} is residing in the Hostel <i style="font-family: Monotype Corsiva">{res.hostel}-{res.room}</i> of this Institute. <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This certificate is issued for the purpose of applying for {reason}.'''
+            return f'''
+            <p>
+                This is to certify that <i>{honorific} {self.student.name.upper()}</i>, ID No. <i>{self.student.bitsId}</i> is a bonafide student of {yearName} year class. {pronoun} was admitted to the Institute on {str(date_admit)}, for pursuing the <i>{branch}</i> {"under dual degree " if dual_degree_student else ""}programme of studies. {pronoun} is residing in the Hostel <i>{res.hostel}-{res.room}</i> of this Institute as on date.
+            </p>
+            { address_html_for_passport if reason == "Passport" else ""}
+            <p>
+                This certificate is issued for the purpose of applying for {reason}.
+            </p>
+            '''.strip()
+
         elif(res.status == "Thesis" or res.status == "PS2"):
-            return f'''&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This is to certify that <i style="font-family: Monotype Corsiva">{gender + self.student.name.upper()}</i>, ID No. <i style="font-family: Monotype Corsiva">{self.student.bitsId}</i> is a bonafide student of {yearName} year class. {pronoun} was admitted to the Institute on {str(date_admit)}, for pursuing the <i style="font-family: Monotype Corsiva">{branch}</i> {"under dual degree " if dual_degree_student else ""}programme of studies. {pronoun} is pursuing <i style="font-family: Monotype Corsiva">{res.status}</i> at <i style="font-family: Monotype Corsiva">{res.psStation}</i>.<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This certificate is issued for the purpose of applying for {reason}.'''
+            return f'''
+            <p>
+                This is to certify that <i>{honorific} {self.student.name.upper()}</i>, ID No. <i>{self.student.bitsId}</i> is a bonafide student of {yearName} year class. {pronoun} was admitted to the Institute on {str(date_admit)}, for pursuing the <i>{branch}</i> {"under dual degree " if dual_degree_student else ""}programme of studies. {pronoun} is pursuing <i>{res.status}</i> at <i>{res.psStation}</i>.
+            </p>
+            { address_html_for_passport if reason == "Passport" else ""}
+            <p>
+                This certificate is issued for the purpose of applying for {reason}.
+            </p>
+            '''.strip()
         else:
             return 'Bonafide is invalid for Graduate students'
 

--- a/swd/main/models.py
+++ b/swd/main/models.py
@@ -264,7 +264,6 @@ class Bonafide(models.Model):
 
         with open(settings.CONSTANTS_LOCATION, 'r') as fp:
             data = json.load(fp)
-        bonafideAcademicSession = data['bonafide-academic-session']
 
         gender = "Mr. " if self.student.gender.lower() == 'm' else "Ms. "
         pronoun = "He " if gender == "Mr. " else "She "
@@ -291,9 +290,9 @@ class Bonafide(models.Model):
             year = today.year
         reason = self.otherReason if self.reason.lower() == 'other' else self.reason
         if(res.status == "Student"):
-            return '''&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This is to certify that <i style="font-family: Monotype Corsiva">''' + gender + self.student.name.upper() + '''</i>, ID No. <i style="font-family: Monotype Corsiva">''' + self.student.bitsId + '''</i> is a bonafide student of ''' + yearName + ''' year class. ''' + pronoun + ''' was admitted to the Institute on ''' + str(date_admit) + ''', for pursuing the <i style="font-family: Monotype Corsiva">''' + branch + '''</i> ''' + ('''under dual degree ''' if dual_degree_student else '''''') + '''programme of studies. ''' + pronoun+'''is residing in the Hostel <i style="font-family: Monotype Corsiva">'''+res.hostel+'''-'''+res.room+'''</i> of this Institute. <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This certificate is issued for the purpose of applying for ''' + reason + '''.'''
+            return f'''&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This is to certify that <i style="font-family: Monotype Corsiva">{gender + self.student.name.upper()}</i>, ID No. <i style="font-family: Monotype Corsiva">{self.student.bitsId}</i> is a bonafide student of {yearName} year class. {pronoun} was admitted to the Institute on {str(date_admit)}, for pursuing the <i style="font-family: Monotype Corsiva">{branch}</i> {"under dual degree " if dual_degree_student else ""}programme of studies. {pronoun} is residing in the Hostel <i style="font-family: Monotype Corsiva">{res.hostel}-{res.room}</i> of this Institute. <br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This certificate is issued for the purpose of applying for {reason}.'''
         elif(res.status == "Thesis" or res.status == "PS2"):
-            return '''&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This is to certify that <i style="font-family: Monotype Corsiva">''' + gender + self.student.name.upper() + '''</i>, ID No. <i style="font-family: Monotype Corsiva">''' + self.student.bitsId + '''</i> is a bonafide student of ''' + yearName + ''' year class. ''' + pronoun + ''' was admitted to the Institute on ''' + str(date_admit) + ''', for pursuing the <i style="font-family: Monotype Corsiva">''' + branch + '''</i> ''' + ('''under dual degree ''' if dual_degree_student else '''''') + '''programme of studies. ''' + pronoun + ''' is pursuing <i style="font-family: Monotype Corsiva">''' + res.status + '''</i> at <i style="font-family: Monotype Corsiva">''' + res.psStation + '''</i>.<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This certificate is issued for the purpose of applying for ''' + reason + '''.'''
+            return f'''&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This is to certify that <i style="font-family: Monotype Corsiva">{gender + self.student.name.upper()}</i>, ID No. <i style="font-family: Monotype Corsiva">{self.student.bitsId}</i> is a bonafide student of {yearName} year class. {pronoun} was admitted to the Institute on {str(date_admit)}, for pursuing the <i style="font-family: Monotype Corsiva">{branch}</i> {"under dual degree " if dual_degree_student else ""}programme of studies. {pronoun} is pursuing <i style="font-family: Monotype Corsiva">{res.status}</i> at <i style="font-family: Monotype Corsiva">{res.psStation}</i>.<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;This certificate is issued for the purpose of applying for {reason}.'''
         else:
             return 'Bonafide is invalid for Graduate students'
 

--- a/swd/main/models.py
+++ b/swd/main/models.py
@@ -257,7 +257,7 @@ class Bonafide(models.Model):
     printed = models.BooleanField(default=0, blank=True)
     status = models.CharField(
         max_length=20, choices=BONAFIDE_STATUS_CHOICES, default='Pending')
-    text = models.TextField(default='', blank=True)
+    text = models.TextField(default='', blank=True) # Better to call createText() when needed
     rejectedReason = models.TextField(default='', blank=True)
 
     def createText(self):

--- a/swd/main/views.py
+++ b/swd/main/views.py
@@ -899,9 +899,9 @@ def certificates(request):
 def printBonafide(request,id=None):
     instance = Bonafide.objects.get(id=id)
     context = {
-            "text"  :instance.createText(),
-            "date"  :date.today(),
-            "id"    :id
+        "text"  :instance.createText(),
+        "date"  :date.today(),
+        "id"    :id
     }
     instance.printed=True
     instance.status='Approved'

--- a/swd/main/views.py
+++ b/swd/main/views.py
@@ -899,7 +899,7 @@ def certificates(request):
 def printBonafide(request,id=None):
     instance = Bonafide.objects.get(id=id)
     context = {
-            "text"  :instance.text,
+            "text"  :instance.createText(),
             "date"  :date.today(),
             "id"    :id
     }

--- a/swd/templates/bonafidepage.html
+++ b/swd/templates/bonafidepage.html
@@ -43,6 +43,18 @@
       margin-left: auto;
       margin-right: auto;
     }
+
+    .certificate-text > p {
+      text-indent: 4ch;
+      font-size: 18px;
+      line-height: 1.25;
+      text-align: justify;
+    }
+
+    .certificate-text i {
+      font-family: 'Monotype Corsiva';
+      font-size: 1.1em;
+    }
   </style>
   <div id="letterhead">
     <img src="{% static 'img/bonafide_header.png' %}" width=595px>
@@ -56,9 +68,9 @@
           style="float:right;">Date: {{ date|date:"d-F-Y" }}</span></h3>
     </div>
     <h2 align="center" style="padding-top: 30px">CERTIFICATE</h1>
-      <p line-height=200% style="font-size: 18px; line-height: 1.5; text-align: justify;">
+      <div class="certificate-text">
         {{ text | safe}}
-      </p>
+      </div>
       <br><br><br>
       <p>
         <span style="text-align:center; float:right; font-size: 20px">


### PR DESCRIPTION
**`views.py`**
The text for each certificate used to be taken from the `text` field of the Bonafide object. Changed it so now it calls `createText()` instead so that this and future changes don't need to be applied to every single Bonafide object.

**`models.py`**
The `createText` function of the Bonafide model is now more readable
The certificate now shows the student's address as well in case the reason is `Passport`

**`bonafidepage.html`**
`.certificate-text` now contains all of the main text in the certificate
The style tag will apply formatting to the text, so now we don't have to inline the styles.