### PR TITLE
Updated mess option selection to preserve old MessOption objects

### DIFF
--- a/swd/main/views.py
+++ b/swd/main/views.py
@@ -330,17 +330,24 @@ def messoption(request):
     leaves = Leave.objects.filter(student=student, dateTimeStart__gte=date.today() - timedelta(days=7))
     daypasss = DayPass.objects.filter(student=student, dateTime__gte=date.today() - timedelta(days=7))
     bonafides = Bonafide.objects.filter(student=student, reqDate__gte=date.today() - timedelta(days=7))
-    messopen = MessOptionOpen.objects.filter(dateClose__gte=date.today(), dateOpen__lte=date.today())
+
+    # MessOptionOpen or None
+    messopen = MessOptionOpen.objects.filter(dateClose__gte=date.today(), dateOpen__lte=date.today()).first() or None
+
+    messoption = None # MessOption or None
     errors = []
 
-    if messopen:
-        messoption = MessOption.objects.filter(monthYear=messopen[0].monthYear, student=student)
+    if messopen: # If there is a MessOptionOpen active right now
+        # Get the student's MessOption
+        messoption = MessOption.objects.filter(student=student, monthYear=messopen.monthYear).first()
     else:
-        messopen_new = MessOptionOpen.objects.all().last()
+        # Get the most recent MessOptionOpen
+        messopen_last = MessOptionOpen.objects.all().last()
+        # Try to get the student's MessOption
         try:
-            messoption = MessOption.objects.filter(monthYear=messopen_new.monthYear, student=student)
+            messoption = MessOption.objects.filter(monthYear=messopen_last.monthYear, student=student).first()
         except:
-            messoption = [ None ]
+            messoption = None
 
     # dues
     try:
@@ -374,10 +381,7 @@ def messoption(request):
         main_amt = data['swd-advance']
     balance = float(main_amt) - float(total_amount)
 
-    edit = 0
-
-    if request.GET:
-        edit = request.GET.get('edit')
+    edit = True if (request.GET and 'edit' in request.GET) else False
     
     context = {
         'student': student,
@@ -388,28 +392,28 @@ def messoption(request):
     }
 
     if messopen and (not messoption or edit):
-        # if messopen is active and student doesn't have a messoption / wants to edit it
+        # If a MessOptionOpen is active and student doesn't have a MessOption / wants to edit it
         # Opens the edit page
         form = MessForm(request.POST)
         context.update({
             'option': 0,
-            'mess': messopen[0],
+            'mess': messopen,
             'form': form,
-            'dateClose': messopen[0].dateClose,
+            'dateClose': messopen.dateClose,
         })
     elif messopen and messoption:
-        # Messopen is active and student already has a messoption
-        # Page shows the messoption and an edit button
+        # Messopen is active and student already has a MessOption
+        # Page shows the MessOption and an edit button
         context.update({
             'option': 1,
-            'mess': messoption[0],
+            'mess': messoption,
         })
     elif messoption:
         # Messopen is not active and student already has a messoption
         # Page shows "you have filled this period's mess as <messname>"
         context.update({
             'option': 2,
-            'mess': messoption[0],
+            'mess': messoption,
         })
     else:
         # messoptionopen is not active and student doesn't have a messoption
@@ -460,31 +464,37 @@ def messoption(request):
         if (vacations.count() and len(errors) == 0) or (vacations.count() == 0) or (edit and len(errors) == 0):
             # Mess Option Filling
             mess = request.POST.get('mess')
-            if messopen[0].capacity != None:
-                if MessOption.objects.filter(mess=mess).count() < messopen[0].capacity:
+            if messopen.capacity != None:
+                if MessOption.objects.filter(monthYear=messopen.monthYear, mess=mess).count() < messopen.capacity:
+                    # Mess isn't full, so create the messoption
                     if edit:
-                        messoption.delete()
-                    messoptionfill = MessOption(
-                        student=student,
-                        monthYear=messopen[0].monthYear,
-                        mess=mess
-                    )
-                    messoptionfill.save()
-                    context['mess'] = messoptionfill
+                        messoption.student = student
+                        messoption.monthYear = messopen.monthYear
+                        messoption.mess = mess
+                    else:
+                        messoption = MessOption(
+                            student = student,
+                            monthYear = messopen.monthYear,
+                            mess = mess
+                        )
+                    messoption.save()
+                    context['mess'] = messoption
                     context['option'] = 1
                 else:
                     context['capacity']="Choose different mess, capacity full."
-            else:
+            else: # In case they gave no capacity, assume it is unlimited
                 if edit:
-                    messoption.delete()
-                messoptionfill = MessOption(
-                    student=student,
-                    monthYear=messopen[0].monthYear,
-                    mess=mess
-                )
-                messoptionfill.save()
-        # if created or (vacations.count() == 0):
-        #     return redirect('messoption')
+                    messoption.student = student
+                    messoption.monthYear = messopen.monthYear
+                    messoption.mess = mess
+                else:
+                    messoption = MessOption(
+                        student = student,
+                        monthYear = messopen.monthYear,
+                        mess = mess
+                    )
+                messoption.save()
+
     return render(request, "mess.html", context)
 
 

--- a/swd/main/views.py
+++ b/swd/main/views.py
@@ -378,58 +378,56 @@ def messoption(request):
 
     if request.GET:
         edit = request.GET.get('edit')
+    
+    context = {
+        'student': student,
+        'balance': balance,
+        'leaves': leaves,
+        'bonafides': bonafides,
+        'daypasss': daypasss,
+    }
 
-    if (messopen and not messoption) or (messopen and edit):
+    if messopen and (not messoption or edit):
+        # if messopen is active and student doesn't have a messoption / wants to edit it
+        # Opens the edit page
         form = MessForm(request.POST)
-        context = {
+        context.update({
             'option': 0,
             'mess': messopen[0],
             'form': form,
             'dateClose': messopen[0].dateClose,
-            'student': student,
-            'balance': balance,
-            'leaves': leaves,
-            'bonafides': bonafides,
-            'daypasss': daypasss,
-        }
+        })
     elif messopen and messoption:
-        context = {
+        # Messopen is active and student already has a messoption
+        # Page shows the messoption and an edit button
+        context.update({
             'option': 1,
             'mess': messoption[0],
-            'student': student,
-            'balance': balance,
-            'leaves': leaves,
-            'bonafides': bonafides,
-            'daypasss': daypasss,}
+        })
     elif messoption:
-        context = {
+        # Messopen is not active and student already has a messoption
+        # Page shows "you have filled this period's mess as <messname>"
+        context.update({
             'option': 2,
-            'student': student,
-            'leaves': leaves,
-            'balance': balance,
-            'bonafides': bonafides,
-            'daypasss': daypasss,
             'mess': messoption[0],
-            }
+        })
     else:
-        context = {
+        # messoptionopen is not active and student doesn't have a messoption
+        # Page shows "Nothing's Here, come back again please!"
+        context.update({
             'option': 3,
-            'student': student,
-            'leaves': leaves,
-            'balance': balance,
-            'bonafides': bonafides,
-            'daypasss': daypasss,
-            }
+        })
     
-    vacations = VacationDatesFill.objects.filter(
-        dateClose__gte=date.today(), dateOpen__lte=date.today()).exclude(
-                messOption=None)
+    vacations = VacationDatesFill.objects \
+        .filter(dateClose__gte=date.today(), dateOpen__lte=date.today()) \
+        .exclude(messOption=None)
     
     if vacations:
         vacation_open = vacations[0]
         student_vacation = Leave.objects.filter(
             student=student,
-            reason=vacation_open.description)
+            reason=vacation_open.description
+        )
         if student_vacation:
             student_vacation = student_vacation[0]
         context['vacation'] = vacation_open
@@ -469,7 +467,8 @@ def messoption(request):
                     messoptionfill = MessOption(
                         student=student,
                         monthYear=messopen[0].monthYear,
-                        mess=mess)
+                        mess=mess
+                    )
                     messoptionfill.save()
                     context['mess'] = messoptionfill
                     context['option'] = 1
@@ -479,9 +478,10 @@ def messoption(request):
                 if edit:
                     messoption.delete()
                 messoptionfill = MessOption(
-                        student=student,
-                        monthYear=messopen[0].monthYear,
-                        mess=mess)
+                    student=student,
+                    monthYear=messopen[0].monthYear,
+                    mess=mess
+                )
                 messoptionfill.save()
         # if created or (vacations.count() == 0):
         #     return redirect('messoption')


### PR DESCRIPTION
# Modified `def messoption` in views.py

The existing system deletes your old `MessOption` object and replaces it. This is a problem because the staff can't see old mess leaves for billing/verifying purposes on `mess_leave_dashboard`.

Setting / editing your mess option in the "MESS OPTION" tab now creates / updates your existing `MessOption` object for the month instead of deleting it.